### PR TITLE
Reduce memory usage when indexing all pages or a namespace

### DIFF
--- a/bin/indexer.php
+++ b/bin/indexer.php
@@ -16,24 +16,33 @@
  *   -q, --quiet              Don't produce any output.
  *   -s <n>, --start <n>      Start at offset.
  *   --no-colors              Don't use any colors in output. Useful when piping output to other tools or files.
+ *   -t <s> --temp-file <s>   Existing temp file to use.
  */
 
 if(!defined('DOKU_INC')) {
-    define('DOKU_INC', realpath(dirname(__FILE__).'/../../../../').'/');
+    define('DOKU_INC', realpath(dirname(__FILE__) . '/../../../../') . '/');
+}
+
+if(!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
 }
 
 define('NOSESSION', 1);
 
 /** @noinspection PhpIncludeInspection */
-require_once(DOKU_INC.'inc/init.php');
+require_once(DOKU_INC . 'inc/init.php');
 
 if(class_exists('DokuCLI') == false) {
     /** @noinspection PhpIncludeInspection */
-    require_once(DOKU_INC.'inc/cli.php');
+    require_once(DOKU_INC . 'inc/cli.php');
 }
 
 require_once(dirname(dirname(__FILE__)) . '/inc/Doku_Indexer_Enhanced.php');
 
+// if memory limit is not set, or is less than 256MB, increase it to 256MB
+if(return_bytes(ini_get('memory_limit')) < (1048576 * 256)) {
+    ini_set('memory_limit', '256M');
+}
 
 /**
  * Update the Search Index from command line
@@ -51,6 +60,15 @@ class EnhancedIndexerCLI extends DokuCLI {
     private $startOffset = 0;
 
     /**
+     * @var SplFileObject
+     */
+    private $temp_file;
+
+    // save the list of files to be indexed in this file instead of an array to reduce memory consumption
+    private static $tempFileName;
+    private static $totalPagesToIndex = 0;
+
+    /**
      * Register options and arguments on the given $options object
      *
      * @param DokuCLI_Options $options
@@ -58,7 +76,7 @@ class EnhancedIndexerCLI extends DokuCLI {
      */
     protected function setup(DokuCLI_Options $options) {
         $options->setHelp(
-            'Updates the search index by indexing all new or changed pages. When the -c option is '.
+            'Updates the search index by indexing all new or changed pages. When the -c option is ' .
             'given the index is cleared first.'
         );
 
@@ -113,21 +131,31 @@ class EnhancedIndexerCLI extends DokuCLI {
             's',
             true
         );
+
+        $options->registerOption(
+            'temp-file',
+            'Existing temp file to use.',
+            't',
+            true
+        );
     }
 
-
-    public function __destruct()
-    {
+    public function __destruct() {
         $this->cleanup();
     }
 
-    private function cleanup()
-    {
+    private function cleanup() {
         if($this->clean == false) {
             $this->quietecho('Saving Indexes...');
             enhanced_idx_get_indexer()->flushIndexes();
             $this->quietecho("done\n");
             $this->clean = true;
+        }
+
+        // release the temp file
+        if(!empty($this->temp_file)) {
+            $this->temp_file = null;
+            unset($this->temp_file);
         }
 
         $this->removeLocks();
@@ -142,13 +170,14 @@ class EnhancedIndexerCLI extends DokuCLI {
      * @return void
      */
     protected function main(DokuCLI_Options $options) {
-        $this->clear = $options->getOpt('clear');
-        $this->quiet = $options->getOpt('quiet');
-        $this->force = $options->getOpt('force');
-        $this->namespace = $options->getOpt('namespace', '');
-        $this->removeLocks = $options->getOpt('remove-locks', '');
-        $this->maxRuns = $options->getOpt('max-runs', 0);
-        $this->startOffset = $options->getOpt('start', 0);
+        $this->clear        = $options->getOpt('clear');
+        $this->quiet        = $options->getOpt('quiet');
+        $this->force        = $options->getOpt('force');
+        $this->namespace    = $options->getOpt('namespace', '');
+        $this->removeLocks  = $options->getOpt('remove-locks', '');
+        $this->maxRuns      = $options->getOpt('max-runs', 0);
+        $this->startOffset  = $options->getOpt('start', 0);
+        self::$tempFileName = $options->getOpt('temp-file', '');
 
         $id = $options->getOpt('id');
 
@@ -158,7 +187,7 @@ class EnhancedIndexerCLI extends DokuCLI {
 
         if($id) {
             $this->index($id);
-            $this->quietecho("done.\n");
+            $this->quietecho("done\n");
         } else {
 
             if($this->clear) {
@@ -175,56 +204,103 @@ class EnhancedIndexerCLI extends DokuCLI {
     function update() {
         global $conf;
 
-        $data = array();
+        // using a lock to prevent the indexer from running multiple instances
         if($this->lock() == false) {
             $this->error('unable to get lock, bailing');
             exit(1);
         }
+
         $this->quietecho("Searching pages... ");
+
+        // are we indexing a single namespace or all files?
         if($this->namespace) {
-            $dir = $conf['datadir'].'/'. str_replace(':', DIRECTORY_SEPARATOR, $this->namespace);
-            $idPrefix = $this->namespace.':';
+            $dir      = $conf['datadir'] . DS . str_replace(':', DS, $this->namespace);
+            $idPrefix = $this->namespace . ':';
         } else {
-            $dir = $conf['datadir'];
+            $dir      = $conf['datadir'];
             $idPrefix = '';
         }
-        search($data, $dir, 'search_allpages', array('skipacl' => true));
-        $this->quietecho(count($data)." pages found.\n");
+
+        // get a temp file name to store the list of files to index
+        if(empty(self::$tempFileName)) {
+
+            self::$tempFileName = sys_get_temp_dir() . '/EnhancedIndexer-' . microtime(true);
+            if(file_exists(self::$tempFileName)) {
+                self::$tempFileName .= 'b';
+            }
+        }
+
+        // we aren't going to use $data, but the search function needs it
+        $data = array();
+        search($data, $dir, 'EnhancedIndexerCLI::save_search_allpages', array('skipacl' => true));
+        $this->quietecho(self::$totalPagesToIndex . " pages found.\n");
 
         $cnt = 0;
 
+        try {
 
-        $length = count($data);
-        for($i=$this->startOffset; $i < $length; $i++) {
+            // we are using the SplFileObject so we can read one line without loading the whole file
+            $this->temp_file = new SplFileObject(self::$tempFileName);
 
-            if(($this->index($idPrefix.$data[$i]['id']))) {
-                $cnt++;
-                $this->clean = false;
+            // this flag tells the SplFileObject to remove the \n from the end of each line it reads
+            $this->temp_file->setFlags(SplFileObject::DROP_NEW_LINE);
+
+            for($i = $this->startOffset; $i < self::$totalPagesToIndex; $i++) {
+
+                // make sure the file handle is still open
+                if(!$this->temp_file->valid()) {
+                    break;
+                }
+
+                // move to the next line and read the page id
+                $this->temp_file->seek($i);
+                $pageId = $this->temp_file->current();
+
+                // index this page, if not done already
+                if(($this->index($idPrefix . $pageId))) {
+                    $cnt++;
+                    $this->clean = false;
+                }
+
+                // used to exit cleanly if ctrl+c is detected
+                if($this->exit) {
+                    break;
+                }
+
+                if(memory_get_usage() > return_bytes(ini_get('memory_limit')) * 0.8) {
+                    // we've used up 80% memory try again.
+                    $this->error('Memory almost full, resetting');
+                    $this->restart($i + 1);
+                }
+
+                if($this->maxRuns && $cnt >= $this->maxRuns) {
+                    $this->error('Max runs reached ' . $cnt . ', restarting');
+                    $this->restart($i + 1);
+                }
             }
 
-            if($this->exit) {
-                exit();
+            // release the temp file
+            if(!empty($this->temp_file)) {
+                $this->temp_file = null;
+                unset($this->temp_file);
             }
+        } catch(Exception $e) {
+            $this->error($e->getMessage());
+        }
 
-            if(memory_get_usage() > return_bytes(ini_get('memory_limit')) * 0.8) {
-                // we've used up 80% memory try again.
-                $this->error('Memory almost full, restarting');
-                $this->restart($i+1);
-            }
-
-            if($this->maxRuns && $cnt >= $this->maxRuns) {
-                $this->error('Max runs reached '.$cnt.', restarting');
-                $this->restart($i+1);
-            }
+        // remove the temp file
+        if(is_file(self::$tempFileName)) {
+            $this->quietecho("Removing temp file... ");
+            unlink(self::$tempFileName);
+            $this->quietecho("done\n");
         }
     }
 
-    function restart($start = 0)
-    {
+    function restart($start = 0) {
         global $argv;
         $this->cleanup();
         $args = $argv;
-        array_unshift($args, '-d', 'memory_limit='.ini_get('memory_limit'));
+        array_unshift($args, '-d', 'memory_limit=' . ini_get('memory_limit'));
 
         foreach($args as $key => $arg) {
             if($arg == '--clear' || $arg == '-c') {
@@ -233,16 +309,14 @@ class EnhancedIndexerCLI extends DokuCLI {
         }
 
         array_push($args, '--start', $start);
+        array_push($args, '--temp-file', self::$tempFileName);
 
         // for running in a debugger
-        if (empty($_SERVER['_'])) {
+        if(empty($_SERVER['_'])) {
             pcntl_exec('/usr/bin/php', $args);
-        }
-        else {
+        } else {
             pcntl_exec($_SERVER['_'], $args);
         }
-
-        exit();
     }
 
     /**
@@ -262,7 +336,7 @@ class EnhancedIndexerCLI extends DokuCLI {
     function clearindex() {
         $this->quietecho("Clearing index... ");
         enhanced_idx_get_indexer()->clear();
-        $this->quietecho("done.\n");
+        $this->quietecho("done\n");
     }
 
     /**
@@ -282,11 +356,11 @@ class EnhancedIndexerCLI extends DokuCLI {
     protected function lock() {
         global $conf;
 
-        $lock = $conf['lockdir'].'/_enhanced_indexer.lock';
-        if (!@mkdir($lock, $conf['dmode'])) {
+        $lock = $conf['lockdir'] . '/_enhanced_indexer.lock';
+        if(!@mkdir($lock, $conf['dmode'])) {
             if(is_dir($lock) && $this->removeLocks) {
                 // looks like a stale lock - remove it
-                if (!@rmdir($lock)) {
+                if(!@rmdir($lock)) {
                     // removing the stale lock failed
                     return false;
                 } else {
@@ -297,36 +371,83 @@ class EnhancedIndexerCLI extends DokuCLI {
                 return false;
             }
         }
-        if (!empty($conf['dperm'])) {
+        if(!empty($conf['dperm'])) {
             chmod($lock, $conf['dperm']);
         }
         return true;
     }
 
-    public function removeLocks()
-    {
+    public function removeLocks() {
         global $conf;
 
         $this->quietecho('clearing lock...');
         $return = true;
 
-        if(is_dir($conf['lockdir'].'/_enhanced_indexer.lock') && !rmdir($conf['lockdir'].'/_enhanced_indexer.lock')) {
-            $this->error('failed to remove '.$conf['lockdir'].'/_enhanced_indexer.lock something is wrong');
-            $return  = false;
+        if(is_dir($conf['lockdir'] . '/_enhanced_indexer.lock') && !rmdir($conf['lockdir'] . '/_enhanced_indexer.lock')) {
+            $this->error('failed to remove ' . $conf['lockdir'] . '/_enhanced_indexer.lock something is wrong');
+            $return = false;
         }
 
-        if(is_dir($conf['lockdir'].'/_indexer.lock') && !rmdir($conf['lockdir'].'/_indexer.lock')) {
-            $this->error('failed to remove '.$conf['lockdir'].'/_indexer.lock something is wrong');
-            $return  = false;
+        if(is_dir($conf['lockdir'] . '/_indexer.lock') && !rmdir($conf['lockdir'] . '/_indexer.lock')) {
+            $this->error('failed to remove ' . $conf['lockdir'] . '/_indexer.lock something is wrong');
+            $return = false;
         }
-        $this->quietecho("done.\n");
+        $this->quietecho("done\n");
 
         return $return;
     }
 
-    public function sigInt()
-    {
+    public function sigInt() {
         $this->exit = true;
+    }
+
+    /**
+     * Just lists all documents
+     *
+     * $opts['depth']   recursion level, 0 for all
+     * $opts['hash']    do md5 sum of content?
+     * $opts['skipacl'] list everything regardless of ACL
+     *
+     * @param $data
+     * @param $base
+     * @param $file
+     * @param $type
+     * @param $lvl
+     * @param $opts
+     * @return bool
+     */
+    public static function save_search_allpages(/** @noinspection PhpUnusedParameterInspection */
+        &$data, $base, $file, $type, $lvl, $opts) {
+
+        if(!empty($opts['depth'])) {
+            $parts = explode('/', ltrim($file, '/'));
+            if(($type == 'd' && count($parts) >= $opts['depth'])
+                || ($type != 'd' && count($parts) > $opts['depth'])
+            ) {
+                return false; // depth reached
+            }
+        }
+
+        //we do nothing with directories
+        if($type == 'd') {
+            return true;
+        }
+
+        //only search txt files
+        if(substr($file, -4) != '.txt') {
+            return true;
+        }
+
+        $pathId = pathID($file);
+
+        if(!$opts['skipacl'] && auth_quickaclcheck($pathId) < AUTH_READ) {
+            return false;
+        }
+
+        file_put_contents(self::$tempFileName, "$pathId\n", FILE_APPEND);
+        self::$totalPagesToIndex++;
+
+        return true;
     }
 }
 
@@ -345,14 +466,22 @@ $conf['cachetime'] = 60 * 60; // default is -1 which means cache isn't used :(
 
 $cli->run();
 
-
-function return_bytes ($size_str)
-{
-    switch (substr ($size_str, -1))
-    {
-        case 'M': case 'm': return (int)$size_str * 1048576;
-        case 'K': case 'k': return (int)$size_str * 1024;
-        case 'G': case 'g': return (int)$size_str * 1073741824;
-        default: return $size_str;
+function return_bytes($size_str) {
+    switch(substr($size_str, -1)) {
+        case 'M':
+        case 'm':
+            return (int) $size_str * 1048576;
+        case 'K':
+        case 'k':
+            return (int) $size_str * 1024;
+        case 'G':
+        case 'g':
+            return (int) $size_str * 1073741824;
+        default:
+            if(is_numeric($size_str)) {
+                return (int) $size_str;
+            } else {
+                return $size_str;
+            }
     }
 }

--- a/inc/Doku_Indexer_Enhanced.php
+++ b/inc/Doku_Indexer_Enhanced.php
@@ -165,26 +165,30 @@ class Doku_Indexer_Enhanced extends Doku_Indexer {
  *
  * Locking is handled internally.
  *
- * @param string        $page   name of the page to index
- * @param boolean       $verbose    print status messages
- * @param boolean       $force  force reindexing even when the index is up to date
+ * @param string    $page       name of the page to index
+ * @param boolean   $verbose    print status messages
+ * @param boolean   $force      force reindexing even when the index is up to date
  * @return boolean              the function completed successfully
  * @author Tom N Harris <tnharris@whoopdedo.org>
  */
 function enhanced_idx_addPage($page, $verbose=false, $force=false) {
+
     $idxtag = metaFN($page,'.indexed');
+
     // check if page was deleted but is still in the index
     if (!page_exists($page)) {
         if (!@file_exists($idxtag)) {
             if ($verbose) print("Indexer: $page does not exist, ignoring".DOKU_LF);
             return false;
         }
+
         $Indexer = enhanced_idx_get_indexer();
         $result = $Indexer->deletePage($page);
         if ($result === "locked") {
             if ($verbose) print("Indexer: locked".DOKU_LF);
             return false;
         }
+
         @unlink($idxtag);
         return $result;
     }
@@ -256,12 +260,14 @@ function enhanced_idx_addPage($page, $verbose=false, $force=false) {
         }
     }
 
-    if ($result)
+    if ($result) {
         io_saveFile(metaFN($page,'.indexed'), idx_get_version());
+    }
+
     if ($verbose) {
         print("Indexer: finished".DOKU_LF);
-        return true;
     }
+
     return $result;
 }
 


### PR DESCRIPTION
Use a temp file to store the id of the files that need indexed rather than storing all the information for the files in an array in memory

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/dokuwiki-enhancedindexer/5)

<!-- Reviewable:end -->
